### PR TITLE
Add a guide for interface content

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -1,0 +1,38 @@
+# Interface content
+
+Having consistent and well defined interface content is fundamental to reach an
+optimal user experience. This guide will define the standards that should be
+followed when designing Aragon products.
+
+## Vocabulary
+
+### DAO vs. Organization
+
+In the user interface, always use “organization” or “Aragon organization”
+instead of “DAO“.
+
+Correct:
+
+> Create an organization
+
+Incorrect:
+
+> Create a DAO
+
+## Grammar and mechanics
+
+### Capitalization
+
+Use sentence case for headings, buttons or actions.
+
+Correct:
+
+> Submit deposit
+
+> Apps in development
+
+Incorrect:
+
+> Submit Deposit
+
+> Apps in Development

--- a/CONTENT.md
+++ b/CONTENT.md
@@ -36,3 +36,15 @@ Incorrect:
 > Submit Deposit
 
 > Apps in Development
+
+### Colon (“:”) in form labels
+
+Do not use a colon at the end of form labels.
+
+Correct:
+
+> Name
+
+Incorrect:
+
+> Name:


### PR DESCRIPTION
Super early version of a guide that would contain everything related to content in Aragon interfaces. We could merge it like this, then extend it as we see things that should be added here.

A great inspiration is the content section of Polaris: https://polaris.shopify.com/content/product-content